### PR TITLE
Fail build when typescript errors are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Serverless Plugin Neo Changelog
 
+## 0.3.2 - November 21, 2022
+
+- Fix a bug that prevented TypeScript compilation errors from failing the build
+
 ## 0.3.1 - October 31, 2022
 
 - Fix a bug that only copied included files if they didn't already exist in the destination

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-plugin-neo",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-plugin-neo",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@vercel/nft": "0.18.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "serverless-plugin-neo",
   "description": "Serverless plugin that compiles TypeScript code and bundles dependencies with node-file-trace",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",
   "license": "MIT",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,11 +227,15 @@ export class NeoPlugin {
       this.servicePathUpdated = true;
     }
 
-    const emittedFiles = await typescript.compile(this.rootFilenames, this.tsconfig, this.log);
+    try {
+      const emittedFiles = await typescript.compile(this.rootFilenames, this.tsconfig, this.log);
 
-    this.log.success('TypeScript compiled');
+      this.log.success('TypeScript compiled');
 
-    return emittedFiles;
+      return emittedFiles;
+    } catch {
+      process.exit(1);
+    }
   }
 
   async copyExtras(): Promise<void> {

--- a/src/lib/typescript.ts
+++ b/src/lib/typescript.ts
@@ -75,12 +75,16 @@ const compile = async (
   const emitResult = program.emit();
   const allDiagnostics = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
 
+  let compilationFailed = false;
+
   allDiagnostics.forEach((diagnostic) => {
     if (diagnostic.file && diagnostic.start) {
       const { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
       const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
 
       if (diagnostic.category === ts.DiagnosticCategory.Error) {
+        compilationFailed = true;
+
         log.error(`${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`);
       } else if (diagnostic.category === ts.DiagnosticCategory.Warning) {
         log.warning(`${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`);
@@ -89,6 +93,10 @@ const compile = async (
       }
     }
   });
+
+  if (compilationFailed) {
+    throw new Error('TypeScript compilation failed');
+  }
 
   if (emitResult.emitSkipped) {
     throw new Error('TypeScript compilation failed');


### PR DESCRIPTION
Fix a bug that prevented TypeScript compilation errors from failing the build

### Updated dependencies

N/A

### Future work

N/A

### Checklist

- [x] Have you fully tested your PR locally?
- [ ] Have you written thorough tests for your work?
- [x] Have you made a CHANGELOG entry?
