### PR TITLE
Runs actions on eks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,14 +8,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: neo-x86-medium
     timeout-minutes: 10
     strategy:
       matrix:
         node: [14, 16, 18]
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: npm


### PR DESCRIPTION
# What Has Changed?
We\'re moving away from GitHub hosted actions runners to running actions on our own Elastic Kubernetes Service (EKS) cluster.
The switch to an EKS environment enables us to manage our environment more effectively, gives us greater control over security measures, optimizes resource utilization, and importantly, ensures cost-efficiency. With EKS, we have the advantage of pricing based on our actual compute resource usage rather than the duration of operations.
This pull request moves all possible actions to run on EKS.